### PR TITLE
enable spaces within imports in react

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1279,6 +1279,7 @@ ij_html_space_inside_empty_tag = false
 ij_html_text_wrap = normal
 
 [{*.tsx,*.jsx}]
+ij_typescript_spaces_within_imports = true
 ij_html_continuation_indent_size = 4
 ij_continuation_indent_size = 4
 


### PR DESCRIPTION
fixes enabling spaces within imports in react